### PR TITLE
Add proper support for multiple instances and Energy Meters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,18 @@ Based on the intial work of [FreshlyBrewedCode]
 ![homee][homee_logo]
 
 ## :information_source: Upgrade from previous Repository
+
 :warning: **Backup homee and Home Assistant!**
 
 1. In HACS click on the homee integration.
 2. In the top right menu click "remove"
-![grafik](https://github.com/FreshlyBrewedCode/hacs-homee/assets/4706817/af69b1da-6f81-4c31-b051-4a58fc264a54)
+   ![grafik](https://github.com/FreshlyBrewedCode/hacs-homee/assets/4706817/af69b1da-6f81-4c31-b051-4a58fc264a54)
 
-4. click "ignore". This way, the integration will be deleted, but the config will stay.
-![grafik](https://github.com/FreshlyBrewedCode/hacs-homee/assets/4706817/29de90d1-2bf4-49ae-8ec4-b48eab737269)
+3. click "ignore". This way, the integration will be deleted, but the config will stay.
+   ![grafik](https://github.com/FreshlyBrewedCode/hacs-homee/assets/4706817/29de90d1-2bf4-49ae-8ec4-b48eab737269)
 
-6. !WITHOUT RESTART! Add [this repository] to HACS and install.
-7. Now restart.
+4. !WITHOUT RESTART! Add [this repository] to HACS and install.
+5. Now restart.
 
 If you want to use the new feature to import all devicess from homee, you have to remove the integration and reinstall.
 

--- a/custom_components/homee/binary_sensor.py
+++ b/custom_components/homee/binary_sensor.py
@@ -49,27 +49,13 @@ def get_device_class(attribute: HomeeAttribute) -> int:
     return (device_class, state_attr)
 
 
-def is_binary_sensor_node(node: HomeeNode):
-    """Determine if a node is a binary sensor based on profile and attributes."""
-    return node.profile in [
-        NodeProfile.LOCK,
-        NodeProfile.OPEN_CLOSE_SENSOR,
-        NodeProfile.OPEN_CLOSE_AND_TEMPERATURE_SENSOR,
-        NodeProfile.OPEN_CLOSE_WITH_TEMPERATURE_AND_BRIGHTNESS_SENSOR,
-        NodeProfile.SMOKE_DETECTOR,
-        NodeProfile.SMOKE_DETECTOR_AND_CODETECTOR,
-        NodeProfile.SMOKE_DETECTOR_AND_SIREN,
-        NodeProfile.SMOKE_DETECTOR_WITH_TEMPERATURE_SENSOR,
-    ]
-
-
 async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_devices):
     """Add the homee platform for the binary sensor integration."""
 
     devices = []
     for node in helpers.get_imported_nodes(hass, config_entry):
         for attribute in node.attributes:
-            if attribute.type in HOMEE_BINARY_SENSOR_ATTRIBUTES:
+            if attribute.type in HOMEE_BINARY_SENSOR_ATTRIBUTES and not attribute.editable:
                 devices.append(HomeeBinarySensor(node, config_entry, attribute))
     if devices:
         async_add_devices(devices)

--- a/custom_components/homee/binary_sensor.py
+++ b/custom_components/homee/binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from pymee.const import AttributeType, NodeProfile
+from pymee.const import AttributeType
 from pymee.model import HomeeAttribute, HomeeNode
 
 from . import HomeeNodeEntity, helpers

--- a/custom_components/homee/binary_sensor.py
+++ b/custom_components/homee/binary_sensor.py
@@ -17,11 +17,11 @@ from .const import CONF_DOOR_GROUPS, CONF_GROUPS, CONF_WINDOW_GROUPS
 _LOGGER = logging.getLogger(__name__)
 
 HOMEE_BINARY_SENSOR_ATTRIBUTES = [
-    AttributeType.OPEN_CLOSE,
-    AttributeType.ON_OFF,
-    AttributeType.LOCK_STATE,
-    AttributeType.SMOKE_ALARM,
     AttributeType.HIGH_TEMPERATURE_ALARM,
+    AttributeType.LOCK_STATE,
+    AttributeType.ON_OFF,
+    AttributeType.OPEN_CLOSE,
+    AttributeType.SMOKE_ALARM,
 ]
 
 
@@ -52,10 +52,10 @@ def get_device_class(attribute: HomeeAttribute) -> int:
 def is_binary_sensor_node(node: HomeeNode):
     """Determine if a node is a binary sensor based on profile and attributes."""
     return node.profile in [
+        NodeProfile.LOCK,
         NodeProfile.OPEN_CLOSE_SENSOR,
         NodeProfile.OPEN_CLOSE_AND_TEMPERATURE_SENSOR,
         NodeProfile.OPEN_CLOSE_WITH_TEMPERATURE_AND_BRIGHTNESS_SENSOR,
-        NodeProfile.LOCK,
         NodeProfile.SMOKE_DETECTOR,
         NodeProfile.SMOKE_DETECTOR_AND_CODETECTOR,
         NodeProfile.SMOKE_DETECTOR_AND_SIREN,

--- a/custom_components/homee/binary_sensor.py
+++ b/custom_components/homee/binary_sensor.py
@@ -21,25 +21,30 @@ HOMEE_BINARY_SENSOR_ATTRIBUTES = [
     AttributeType.ON_OFF,
     AttributeType.LOCK_STATE,
     AttributeType.SMOKE_ALARM,
+    AttributeType.HIGH_TEMPERATURE_ALARM,
 ]
 
 
-def get_device_class(node: HomeeNodeEntity) -> int:
+def get_device_class(attribute: HomeeAttribute) -> int:
     """Determine the device class a homee node based on the available attributes."""
     device_class = BinarySensorDeviceClass.OPENING
     state_attr = AttributeType.OPEN_CLOSE
 
-    if node._on_off.type == AttributeType.ON_OFF:
+    if attribute.type == AttributeType.ON_OFF:
         state_attr = AttributeType.ON_OFF
         device_class = BinarySensorDeviceClass.PLUG
 
-    if node._on_off.type == AttributeType.LOCK_STATE:
+    if attribute.type == AttributeType.LOCK_STATE:
         state_attr = AttributeType.LOCK_STATE
         device_class = BinarySensorDeviceClass.LOCK
 
-    if node._on_off.type == AttributeType.SMOKE_ALARM:
+    if attribute.type == AttributeType.SMOKE_ALARM:
         state_attr = AttributeType.SMOKE_ALARM
         device_class = BinarySensorDeviceClass.SMOKE
+
+    if attribute.type == AttributeType.HIGH_TEMPERATURE_ALARM:
+        state_attr = AttributeType.HIGH_TEMPERATURE_ALARM
+        device_class = BinarySensorDeviceClass.HEAT
 
     return (device_class, state_attr)
 
@@ -98,7 +103,7 @@ class HomeeBinarySensor(HomeeNodeEntity, BinarySensorEntity):
         """Configure the device class of the sensor."""
 
         # Get the initial device class and state attribute
-        self._device_class, self._state_attr = get_device_class(self)
+        self._device_class, self._state_attr = get_device_class(self._on_off)
 
         # Set Window/Door device class based on configured groups
         if any(

--- a/custom_components/homee/cover.py
+++ b/custom_components/homee/cover.py
@@ -19,9 +19,9 @@ from . import HomeeNodeEntity, helpers
 _LOGGER = logging.getLogger(__name__)
 
 OPEN_CLOSE_ATTRIBUTES = [
-    AttributeType.UP_DOWN,
     AttributeType.OPEN_CLOSE,
     AttributeType.SLAT_ROTATION_IMPULSE,
+    AttributeType.UP_DOWN,
 ]
 POSITION_ATTRIBUTES = [AttributeType.POSITION, AttributeType.SHUTTER_SLAT_POSITION]
 

--- a/custom_components/homee/light.py
+++ b/custom_components/homee/light.py
@@ -2,7 +2,7 @@
 
 import logging
 
-import homeassistant
+from homeassistant.core import HomeAssistant
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
@@ -94,7 +94,7 @@ def decimal_to_rgb_list(color):
     return [(color & 0xFF0000) >> 16, (color & 0x00FF00) >> 8, (color & 0x0000FF)]
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_devices):
     """Add the homee platform for the light integration."""
 
     devices = []
@@ -115,7 +115,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
         async_add_devices(devices)
 
 
-async def async_unload_entry(hass: homeassistant, entry: ConfigEntry):
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
     return True
 

--- a/custom_components/homee/light.py
+++ b/custom_components/homee/light.py
@@ -28,11 +28,11 @@ from .const import HOMEE_LIGHT_MAX_MIRED, HOMEE_LIGHT_MIN_MIRED
 _LOGGER = logging.getLogger(__name__)
 
 LIGHT_ATTRIBUTES = [
-    AttributeType.DIMMING_LEVEL,
     AttributeType.COLOR,
-    AttributeType.HUE,
-    AttributeType.COLOR_TEMPERATURE,
     AttributeType.COLOR_MODE,
+    AttributeType.COLOR_TEMPERATURE,
+    AttributeType.DIMMING_LEVEL,
+    AttributeType.HUE,
 ]
 
 

--- a/custom_components/homee/sensor.py
+++ b/custom_components/homee/sensor.py
@@ -16,12 +16,19 @@ from . import HomeeNodeEntity, helpers
 
 _LOGGER = logging.getLogger(__name__)
 
-VALID_ATTRIBUTES = [
+SENSOR_ATTRIBUTES = [
     AttributeType.CURRENT_ENERGY_USE,
     AttributeType.ACCUMULATED_ENERGY_USE,
     AttributeType.POSITION,
     AttributeType.UP_DOWN,
-    AttributeType.BATTERY_LEVEL
+    AttributeType.BATTERY_LEVEL,
+    AttributeType.CURRENT,
+    AttributeType.VOLTAGE,
+    AttributeType.TOTAL_VOLTAGE,
+    AttributeType.TOTAL_CURRENT_ENERGY_USE,
+    AttributeType.TOTAL_ACCUMULATED_ENERGY_USE,
+    AttributeType.TOTAL_CURRENT,
+    AttributeType.DEVICE_TEMPERATURE,
 ]
 
 MEASUREMENT_ATTRIBUTES = [
@@ -29,21 +36,45 @@ MEASUREMENT_ATTRIBUTES = [
     AttributeType.POSITION,
     AttributeType.UP_DOWN,
     AttributeType.BATTERY_LEVEL,
+    AttributeType.CURRENT,
+    AttributeType.VOLTAGE,
+    AttributeType.TOTAL_CURRENT_ENERGY_USE,
+    AttributeType.TOTAL_CURRENT,
+    AttributeType.DEVICE_TEMPERATURE,
+]
+
+TOTAL_INCREASING_ATTRIBUTES = [
+    AttributeType.ACCUMULATED_ENERGY_USE,
+    AttributeType.TOTAL_ACCUMULATED_ENERGY_USE,
 ]
 
 
 def get_device_class(attribute: HomeeAttribute) -> int:
     """Determine the device class a homee node based on the node profile."""
-    if attribute.type == AttributeType.CURRENT_ENERGY_USE:
-        return SensorDeviceClass.POWER
+    device_class = None
 
-    if attribute.type == AttributeType.ACCUMULATED_ENERGY_USE:
-        return SensorDeviceClass.ENERGY
+    if attribute.type == AttributeType.CURRENT_ENERGY_USE:
+        device_class = SensorDeviceClass.POWER
+
+    if attribute.type in [AttributeType.ACCUMULATED_ENERGY_USE, AttributeType.TOTAL_ACCUMULATED_ENERGY_USE]:
+        device_class = SensorDeviceClass.ENERGY
 
     if attribute.type == AttributeType.BATTERY_LEVEL:
-        return SensorDeviceClass.BATTERY
+        device_class = SensorDeviceClass.BATTERY
 
-    return None
+    if attribute.type in [AttributeType.VOLTAGE, AttributeType.TOTAL_VOLTAGE]:
+        device_class = SensorDeviceClass.VOLTAGE
+
+    if attribute.type in [AttributeType.CURRENT, AttributeType.TOTAL_CURRENT]:
+        device_class = SensorDeviceClass.CURRENT
+
+    if attribute.type in [AttributeType.DEVICE_TEMPERATURE, AttributeType.TEMPERATURE]:
+        device_class = SensorDeviceClass.TEMPERATURE
+
+    if attribute.type in [AttributeType.CURRENT_ENERGY_USE, AttributeType.TOTAL_CURRENT_ENERGY_USE]:
+        device_class = SensorDeviceClass.POWER
+
+    return device_class
 
 
 def get_state_class(attribute: HomeeAttribute) -> int:
@@ -51,7 +82,7 @@ def get_state_class(attribute: HomeeAttribute) -> int:
     if attribute.type in MEASUREMENT_ATTRIBUTES:
         return SensorStateClass.MEASUREMENT
 
-    if attribute.type == AttributeType.ACCUMULATED_ENERGY_USE:
+    if attribute.type in TOTAL_INCREASING_ATTRIBUTES:
         return SensorStateClass.TOTAL_INCREASING
 
     return None
@@ -62,14 +93,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_devices
 
     devices = []
     for node in helpers.get_imported_nodes(hass, config_entry):
-        sensor_type_counts = {}
         for attribute in node.attributes:
-            if attribute.type not in sensor_type_counts:
-                sensor_type_counts[attribute.type] = 0
-            if attribute.type in VALID_ATTRIBUTES:
-                sensor_index = sensor_type_counts[attribute.type]
-                devices.append(HomeeSensor(node, config_entry, attribute, sensor_index))
-                sensor_type_counts[attribute.type] += 1
+            if attribute.type in SENSOR_ATTRIBUTES:
+                devices.append(HomeeSensor(node, config_entry, attribute))
     if devices:
         async_add_devices(devices)
 
@@ -83,20 +109,20 @@ class HomeeSensor(HomeeNodeEntity, SensorEntity):
     """Representation of a homee sensor."""
 
     _attr_has_entity_name = True
+    _attr_name = None
 
     def __init__(
         self,
         node: HomeeNode,
         entry: ConfigEntry,
-        measurement_attribute: HomeeAttribute = None,
-        sensor_index=0,
+        measurement_attribute: HomeeAttribute = None
     ) -> None:
         """Initialize a homee sensor entity."""
         HomeeNodeEntity.__init__(self, node, self, entry)
         self._measurement = measurement_attribute
         self._device_class = get_device_class(measurement_attribute)
         self._state_class = get_state_class(measurement_attribute)
-        self._sensor_index = sensor_index
+        self._sensor_index = measurement_attribute.instance
 
         self._unique_id = f"{self._node.id}-sensor-{self._measurement.id}"
 
@@ -113,7 +139,7 @@ class HomeeSensor(HomeeNodeEntity, SensorEntity):
                     name = f"{key}"
 
         if self._sensor_index > 0:
-            name = f"{name} {self._sensor_index + 1}"
+            name = f"{name} {self._sensor_index}"
 
         return name
 

--- a/custom_components/homee/sensor.py
+++ b/custom_components/homee/sensor.py
@@ -23,10 +23,10 @@ SENSOR_ATTRIBUTES = [
     AttributeType.CURRENT_ENERGY_USE,
     AttributeType.DEVICE_TEMPERATURE,
     AttributeType.POSITION,
-    AttributeType.TOTAL_VOLTAGE,
-    AttributeType.TOTAL_CURRENT_ENERGY_USE,
     AttributeType.TOTAL_ACCUMULATED_ENERGY_USE,
     AttributeType.TOTAL_CURRENT,
+    AttributeType.TOTAL_CURRENT_ENERGY_USE,
+    AttributeType.TOTAL_VOLTAGE,
     AttributeType.UP_DOWN,
     AttributeType.VOLTAGE,
 ]

--- a/custom_components/homee/sensor.py
+++ b/custom_components/homee/sensor.py
@@ -17,30 +17,30 @@ from . import HomeeNodeEntity, helpers
 _LOGGER = logging.getLogger(__name__)
 
 SENSOR_ATTRIBUTES = [
-    AttributeType.CURRENT_ENERGY_USE,
     AttributeType.ACCUMULATED_ENERGY_USE,
-    AttributeType.POSITION,
-    AttributeType.UP_DOWN,
     AttributeType.BATTERY_LEVEL,
     AttributeType.CURRENT,
-    AttributeType.VOLTAGE,
+    AttributeType.CURRENT_ENERGY_USE,
+    AttributeType.DEVICE_TEMPERATURE,
+    AttributeType.POSITION,
     AttributeType.TOTAL_VOLTAGE,
     AttributeType.TOTAL_CURRENT_ENERGY_USE,
     AttributeType.TOTAL_ACCUMULATED_ENERGY_USE,
     AttributeType.TOTAL_CURRENT,
-    AttributeType.DEVICE_TEMPERATURE,
+    AttributeType.UP_DOWN,
+    AttributeType.VOLTAGE,
 ]
 
 MEASUREMENT_ATTRIBUTES = [
-    AttributeType.CURRENT_ENERGY_USE,
-    AttributeType.POSITION,
-    AttributeType.UP_DOWN,
     AttributeType.BATTERY_LEVEL,
     AttributeType.CURRENT,
+    AttributeType.CURRENT_ENERGY_USE,
+    AttributeType.DEVICE_TEMPERATURE,
+    AttributeType.POSITION,
+    AttributeType.UP_DOWN,
     AttributeType.VOLTAGE,
     AttributeType.TOTAL_CURRENT_ENERGY_USE,
     AttributeType.TOTAL_CURRENT,
-    AttributeType.DEVICE_TEMPERATURE,
 ]
 
 TOTAL_INCREASING_ATTRIBUTES = [
@@ -56,7 +56,10 @@ def get_device_class(attribute: HomeeAttribute) -> int:
     if attribute.type == AttributeType.CURRENT_ENERGY_USE:
         device_class = SensorDeviceClass.POWER
 
-    if attribute.type in [AttributeType.ACCUMULATED_ENERGY_USE, AttributeType.TOTAL_ACCUMULATED_ENERGY_USE]:
+    if attribute.type in [
+        AttributeType.ACCUMULATED_ENERGY_USE,
+        AttributeType.TOTAL_ACCUMULATED_ENERGY_USE
+    ]:
         device_class = SensorDeviceClass.ENERGY
 
     if attribute.type == AttributeType.BATTERY_LEVEL:

--- a/custom_components/homee/switch.py
+++ b/custom_components/homee/switch.py
@@ -30,6 +30,7 @@ HOMEE_SWITCH_ATTRIBUTES = [
     AttributeType.OPEN_PARTIAL_IMPULSE,
     AttributeType.ON_OFF,
     AttributeType.PERMANENTLY_OPEN_IMPULSE,
+    AttributeType.RESET_METER,
     AttributeType.SIREN,
     AttributeType.SLAT_ROTATION_IMPULSE,
     AttributeType.VENTILATE_IMPULSE,

--- a/custom_components/homee/switch.py
+++ b/custom_components/homee/switch.py
@@ -49,12 +49,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_devices
 
     devices = []
     for node in helpers.get_imported_nodes(hass, config_entry):
-        switch_count = 0
         for attribute in node.attributes:
             # These conditions identify a switch.
             if attribute.type in HOMEE_SWITCH_ATTRIBUTES and attribute.editable:
-                devices.append(HomeeSwitch(node, config_entry, attribute, switch_count))
-                switch_count += 1
+                devices.append(HomeeSwitch(node, config_entry, attribute))
     if devices:
         async_add_devices(devices)
 
@@ -73,13 +71,12 @@ class HomeeSwitch(HomeeNodeEntity, SwitchEntity):
         self,
         node: HomeeNode,
         entry: ConfigEntry,
-        on_off_attribute: HomeeAttribute = None,
-        switch_index=-1,
+        on_off_attribute: HomeeAttribute = None
     ) -> None:
         """Initialize a homee switch entity."""
         HomeeNodeEntity.__init__(self, node, self, entry)
         self._on_off = on_off_attribute
-        self._switch_index = switch_index
+        self._switch_index = on_off_attribute.instance
         self._device_class = get_device_class(node)
 
         self._unique_id = f"{self._node.id}-switch-{self._on_off.id}"
@@ -100,7 +97,7 @@ class HomeeSwitch(HomeeNodeEntity, SwitchEntity):
             return None
 
         if self._switch_index > 0:
-            return f"switch {self._switch_index + 1}"
+            return f"switch {self._switch_index}"
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/homee/switch.py
+++ b/custom_components/homee/switch.py
@@ -23,16 +23,16 @@ HOMEE_PLUG_PROFILES = [
 ]
 
 HOMEE_SWITCH_ATTRIBUTES = [
-    AttributeType.ON_OFF,
+    AttributeType.AUTOMATIC_MODE_IMPULSE,
+    AttributeType.BRIEFLY_OPEN_IMPULSE,
     AttributeType.IMPULSE,
     AttributeType.LIGHT_IMPULSE,
     AttributeType.OPEN_PARTIAL_IMPULSE,
-    AttributeType.AUTOMATIC_MODE_IMPULSE,
-    AttributeType.BRIEFLY_OPEN_IMPULSE,
+    AttributeType.ON_OFF,
     AttributeType.PERMANENTLY_OPEN_IMPULSE,
+    AttributeType.SIREN,
     AttributeType.SLAT_ROTATION_IMPULSE,
     AttributeType.VENTILATE_IMPULSE,
-    AttributeType.SIREN
 ]
 
 

--- a/info.md
+++ b/info.md
@@ -31,17 +31,18 @@ Based on the intial work of [FreshlyBrewedCode]
 ![homee][homee_logo]
 
 ## :information_source: Upgrade from previous Repository
+
 :warning: **Backup homee and Home Assistant!**
 
 1. In HACS click on the homee integration.
 2. In the top right menu click "remove"
-![grafik](https://github.com/FreshlyBrewedCode/hacs-homee/assets/4706817/af69b1da-6f81-4c31-b051-4a58fc264a54)
+   ![grafik](https://github.com/FreshlyBrewedCode/hacs-homee/assets/4706817/af69b1da-6f81-4c31-b051-4a58fc264a54)
 
-4. click "ignore". This way, the integration will be deleted, but the config will stay.
-![grafik](https://github.com/FreshlyBrewedCode/hacs-homee/assets/4706817/29de90d1-2bf4-49ae-8ec4-b48eab737269)
+3. click "ignore". This way, the integration will be deleted, but the config will stay.
+   ![grafik](https://github.com/FreshlyBrewedCode/hacs-homee/assets/4706817/29de90d1-2bf4-49ae-8ec4-b48eab737269)
 
-6. !WITHOUT RESTART! Add [this repository] to HACS and install.
-7. Now restart.
+4. !WITHOUT RESTART! Add [this repository] to HACS and install.
+5. Now restart.
 
 If you want to use the new feature to import all devicess from homee, you have to remove the integration and reinstall.
 


### PR DESCRIPTION
With this change, the "instance" property of HomeeAttributes is used to number multiple sensors and switches of the same type on a single device.
Also more sensor and switch types are supported to fully support energy meters.
