### PR TITLE
show homee status if only groups imported / add watchdog on-off

### DIFF
--- a/custom_components/homee/alarm_control_panel.py
+++ b/custom_components/homee/alarm_control_panel.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
-    AlarmControlPanelEntityFeature
+    AlarmControlPanelEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
 
@@ -42,10 +42,8 @@ async def async_setup_entry(
     for node in helpers.get_imported_nodes(hass, config_entry):
         for attribute in node.attributes:
             # These conditions identify a switch.
-            if (
-                attribute.type == AttributeType.HOMEE_MODE and
-                attribute.editable
-            ):
+            if attribute.type == AttributeType.HOMEE_MODE and\
+               attribute.editable:
                 devices.append(HomeeAlarmPanel(node, config_entry, attribute))
     if devices:
         async_add_devices(devices)
@@ -65,7 +63,7 @@ class HomeeAlarmPanel(HomeeNodeEntity, AlarmControlPanelEntity):
         self,
         node: HomeeNode,
         entry: ConfigEntry,
-        alarm_panel_attribute: HomeeAttribute = None
+        alarm_panel_attribute: HomeeAttribute = None,
     ) -> None:
         """Initialize a homee alarm Control panel entity."""
         HomeeNodeEntity.__init__(self, node, self, entry)
@@ -74,8 +72,9 @@ class HomeeAlarmPanel(HomeeNodeEntity, AlarmControlPanelEntity):
         self._attr_supported_features = get_features(alarm_panel_attribute)
         self._attr_translation_key = "homee_status"
 
-        self._unique_id = (f"{self._node.id}-alarm_panel-"
-                           f"{self._alarm_panel_attribute.id}")
+        self._unique_id = (
+            f"{self._node.id}-alarm_panel-" f"{self._alarm_panel_attribute.id}"
+        )
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -87,7 +86,7 @@ class HomeeAlarmPanel(HomeeNodeEntity, AlarmControlPanelEntity):
             manufacturer="homee",
             model="homee",
             sw_version=homee.settings.version,
-            hw_version="TBD"
+            hw_version="TBD",
         )
 
     @property

--- a/custom_components/homee/helpers.py
+++ b/custom_components/homee/helpers.py
@@ -24,7 +24,8 @@ def get_imported_nodes(
     groups = [
         homee.get_group_by_id(int(g))
         for g in config_entry.options[CONF_GROUPS].get(
-            CONF_IMPORT_GROUPS, all_groups
+            CONF_IMPORT_GROUPS,
+            all_groups
         )
     ]
 
@@ -36,6 +37,9 @@ def get_imported_nodes(
             if node not in nodes:
                 nodes.append(node)
 
+    # Always add homee itself to the nodes.
+    nodes.append(homee.get_node_by_id(-1))
+
     return nodes
 
 
@@ -44,7 +48,8 @@ def get_attribute_for_enum(att_class, att_id):
     attributes = [
         a
         for a in inspect.getmembers(
-            att_class, lambda a: not inspect.isroutine(a)
+            att_class,
+            lambda a: not inspect.isroutine(a)
         )
         if not (a[0].startswith("__") and a[0].endswith("__"))
     ]

--- a/custom_components/homee/strings.json
+++ b/custom_components/homee/strings.json
@@ -256,6 +256,9 @@
       },
       "reset_meter_4": {
         "name": "Reset Meter 4"
+      },
+      "watchdog_on_off": {
+        "name": "Watchdog"
       }
     },
     "alarm_control_panel": {

--- a/custom_components/homee/switch.py
+++ b/custom_components/homee/switch.py
@@ -34,6 +34,7 @@ HOMEE_SWITCH_ATTRIBUTES = [
     AttributeType.SIREN,
     AttributeType.SLAT_ROTATION_IMPULSE,
     AttributeType.VENTILATE_IMPULSE,
+    AttributeType.WATCHDOG_ON_OFF,
 ]
 
 DESCRIPTIVE_ATTRIBUTES = [
@@ -45,6 +46,7 @@ DESCRIPTIVE_ATTRIBUTES = [
     AttributeType.RESET_METER,
     AttributeType.SLAT_ROTATION_IMPULSE,
     AttributeType.VENTILATE_IMPULSE,
+    AttributeType.WATCHDOG_ON_OFF
 ]
 
 
@@ -129,6 +131,13 @@ class HomeeSwitch(HomeeNodeEntity, SwitchEntity):
     def is_on(self) -> bool:
         """Return True if entity is on."""
         return bool(self._on_off.current_value)
+
+    @property
+    def icon(self) -> str | None:
+        if self._on_off.type == AttributeType.WATCHDOG_ON_OFF:
+            return "mdi:dog"
+
+        return None
 
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""

--- a/custom_components/homee/switch.py
+++ b/custom_components/homee/switch.py
@@ -134,6 +134,7 @@ class HomeeSwitch(HomeeNodeEntity, SwitchEntity):
 
     @property
     def icon(self) -> str | None:
+        """Return icon if different from main feature."""
         if self._on_off.type == AttributeType.WATCHDOG_ON_OFF:
             return "mdi:dog"
 

--- a/custom_components/homee/translations/en.json
+++ b/custom_components/homee/translations/en.json
@@ -256,6 +256,9 @@
       },
       "reset_meter_4": {
         "name": "Reset Meter 4"
+      },
+      "watchdog_on_off": {
+        "name": "Watchdog"
       }
     },
     "alarm_control_panel": {


### PR DESCRIPTION
This fixes that homee status is not shown if only devices from certain groups are imported.
It also adds the Watchdog ON/OFF switch to all homee devices